### PR TITLE
Always serve json.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -65,7 +65,7 @@ module.exports = class Server {
         const status = this._getMutatedStatus(req);
         const body = mutatedJson;
         this.responseHandler(status, body);
-        res.status(status).send(body);
+        res.status(status).json(body);
       })
       .catch((err = []) => {
         this.responseHandler(err[0], err[1]);


### PR DESCRIPTION
When a file with the contents `"value"` was served, the quotes were stripped away by parsing as json and using `res.send()`. `res.json()` will output normal strings (which are valid json) in the correct format.
