### PR TITLE
Reimplementation of CORS headers using cors package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "command-line-args": "^2.1.4",
+    "cors": "^2.7.1",
     "express": "^4.13.4",
     "json-pointer": "^0.5.0"
   },

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import Path from 'path';
 import FS from 'fs';
 import JsonPointer from 'json-pointer';
+import cors from 'cors';
 
 module.exports = class Server {
   constructor(config) {
@@ -10,8 +11,10 @@ module.exports = class Server {
     this.name = config.name;
     this.port = config.port;
     this.dir = config.dir;
+    this.cors = config.cors || {};
 
     this.express = express();
+    this.express.use(this.setupCors());
     this.express.get('*', (req, res) => {
       this.getHandler(req, res);
     });
@@ -43,12 +46,14 @@ module.exports = class Server {
     }
   }
 
+  setupCors() {
+    const corsConfig = Object.assign({ origin: '*', credentials: true }, this.cors);
+    console.log('corsConfig', corsConfig);
+    return cors(corsConfig);
+  }
+
   getHandler(req, res) {
     const filePath = Path.resolve(this.dir + req.path);
-
-    // Allow all the things, security is overrated
-    res.set('Access-Control-Allow-Origin', req.get('origin'));
-    res.set('Access-Control-Allow-Credentials', true);
 
     // Get file and serve it
     this._resolveFilePath(filePath)

--- a/test/cors.js
+++ b/test/cors.js
@@ -1,0 +1,101 @@
+const fetchUrl = require('fetch').fetchUrl;
+const expect = require('chai').expect;
+const MockedApi = require('../src');
+
+const baseConfig = { port:3000, dir:`${__dirname}/mocks` };
+const baseUrl = 'http://localhost:3000';
+
+delete require.cache[require.resolve('../src')];
+
+function getMockedApiWithCors(corsConfig, done, callback) {
+  const config = Object.assign({ cors: corsConfig }, baseConfig);
+  return MockedApi.setup(config);
+}
+
+describe('cors config', () => {
+
+  describe('as default', () => {
+    const server = getMockedApiWithCors(null);
+
+    before((done) => {
+      server.start().then(done, done);
+    });
+
+    after(() => {
+      server.stop();
+    });
+
+    it('has an Access-Control-Allow-Origin header', (done) => {
+      fetchUrl(`${baseUrl}/42.json`, (err, meta, body) => {
+        expect(meta.responseHeaders['access-control-allow-origin']).to.equal('*');
+        expect(meta.responseHeaders['access-control-allow-credentials']).to.equal('true');
+        done();
+      });
+    });
+  });
+
+  describe('with origin', () => {
+    const server = getMockedApiWithCors({ origin: 'foo' });
+
+    before((done) => {
+      server.start().then(done, done);
+    });
+
+    after(() => {
+      server.stop();
+    });
+
+    it('has a correct Access-Control-Allow-Origin header', (done) => {
+      fetchUrl(`${baseUrl}/42.json`, (err, meta, body) => {
+        expect(meta.responseHeaders['access-control-allow-origin']).to.equal('foo');
+        done();
+      });
+    });
+  });
+
+  describe('with origin as regex that does not match', () => {
+    const server = getMockedApiWithCors({ origin: /^you-shall-not-match$/ });
+
+    before((done) => {
+      server.start().then(done, done);
+    });
+
+    after(() => {
+      server.stop();
+    });
+
+    it('has no Access-Control-Allow-Origin header', (done) => {
+      fetchUrl(`${baseUrl}/42.json`, (err, meta, body) => {
+        expect(meta.responseHeaders['access-control-allow-origin']).not.to.exist;
+        done();
+      });
+    });
+  });
+
+  describe('with allowedHeaders', () => {
+    const server = getMockedApiWithCors({ allowedHeaders: [ 'Content-Type' ] });
+
+    before((done) => {
+      server.start().then(done, done);
+    });
+
+    after(() => {
+      server.stop();
+    });
+
+    it('OPTIONS request has a Access-Control-Allow-Headers header', (done) => {
+      fetchUrl(`${baseUrl}/42.json`, { method: 'OPTIONS' }, (err, meta, body) => {
+        expect(meta.responseHeaders['access-control-allow-headers']).to.equal('Content-Type');
+        done();
+      });
+    });
+
+    it('GET request should not have a Access-Control-Allow-Headers header', (done) => {
+      fetchUrl(`${baseUrl}/42.json`, { method: 'GET' }, (err, meta, body) => {
+        expect(meta.responseHeaders['access-control-allow-headers']).not.to.exist;
+        done();
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
I guess taking a dependency on cors was initially avoided on purpose, the omission of OPTIONS request handling limits the use case for GET requests. A complex client-side XHR might trigger the browser to issue a pre-flight request.
I think it's better to use the `cors` package, and allow the user of mocked api to configure it when the default options are not sufficient.

I will close #15.
