### PR TITLE
cors '*' with credentials is breaking in browsers

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -47,7 +47,7 @@ module.exports = class Server {
   }
 
   setupCors() {
-    const corsConfig = { origin: '*', credentials: true, ...this.cors };
+    const corsConfig = { origin: true, credentials: true, ...this.cors };
     return cors(corsConfig);
   }
 


### PR DESCRIPTION
Setting origin option to true will reflect Origin header instead of returning '*'
https://github.com/expressjs/cors#configuration-options
